### PR TITLE
Add basic ID validation and information extraction.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ fmt:
 	go fmt ./...
 
 vet:
-	go vet ./..。
+	go vet ./...
 
 test:
 	go test ./... -cover -coverprofile=coverage -covermode=atomic -race -v

--- a/id_validator_basic.go
+++ b/id_validator_basic.go
@@ -1,0 +1,73 @@
+package idvalidator
+
+import (
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cast"
+)
+
+// BasicIdInfo 不含地址码的身份证信息
+type BasicIdInfo struct {
+	Birthday      time.Time
+	Constellation string
+	ChineseZodiac string
+	Sex           int
+	Length        int
+	CheckBit      string
+}
+
+// IsValidBasic 验证身份证号除地址信息之外的合法性
+func IsValidBasic(id string) bool {
+	code, err := generateCode(id)
+	if err != nil {
+		return false
+	}
+
+	// 检查顺序码、生日码、地址码
+	if !checkOrderCode(code["order"]) || !checkBirthdayCode(code["birthdayCode"]) {
+		return false
+	}
+
+	// 15位身份证不含校验码
+	if code["type"] == "15" {
+		return true
+	}
+
+	// 校验码
+	return code["checkBit"] == generatorCheckBit(code["body"])
+}
+
+// GetBasicInfo 获取除地址信息之外的身份证信息
+func GetBasicInfo(id string) (BasicIdInfo, error) {
+	// 验证有效性
+	if !IsValidBasic(id) {
+		return BasicIdInfo{}, errors.New("invalid ID card number")
+	}
+
+	code, _ := generateCode(id)
+
+	// 生日
+	cst, _ := time.LoadLocation("Asia/Shanghai")
+	birthday, _ := time.ParseInLocation("20060102", code["birthdayCode"], cst)
+
+	// 性别
+	sex := 1
+	order, _ := strconv.Atoi(code["order"])
+	if (order % 2) == 0 {
+		sex = 0
+	}
+
+	// 长度
+	length := cast.ToInt(code["type"])
+
+	return BasicIdInfo{
+		Birthday:      birthday,
+		Constellation: getConstellation(code["birthdayCode"]),
+		ChineseZodiac: getChineseZodiac(code["birthdayCode"]),
+		Sex:           sex,
+		Length:        length,
+		CheckBit:      code["checkBit"],
+	}, nil
+}

--- a/id_validator_basic_test.go
+++ b/id_validator_basic_test.go
@@ -1,0 +1,36 @@
+package idvalidator
+
+import (
+	"testing"
+)
+
+// go test -v -cover -coverprofile=cover.out
+// go tool cover -func=cover.out
+// go tool cover -html=cover.out
+func TestIsValidBasic(t *testing.T) {
+	errIds := []string{
+		"44030819990110",     // 号码位数不合法
+		"440308199902301512", // 出生日期码不合法
+		"440308199901101513", // 验证码不合法
+		"610104620932690",    // 出生日期码不合法
+		"11010119900307867X", // 校验位不合法
+		"TES12345678901 j",   // 特殊字符格式不合法
+	}
+	for _, id := range errIds {
+		if IsValidBasic(id) {
+			t.Errorf("ID must be invalid.: %s", id)
+		}
+	}
+}
+
+func TestGetInfoBasic(t *testing.T) {
+	_, e1 := GetBasicInfo("440301197110292910")
+	if e1 != nil {
+		t.Errorf("`e1` must be nil.: %v", e1)
+	}
+
+	_, e2 := GetBasicInfo("500154199302305886")
+	if e2 == nil {
+		t.Errorf("`e2` must not be nil.: %v", e2)
+	}
+}


### PR DESCRIPTION
## **User description**
增加了一个除地址信息码之外的基础信息校验和信息提取。
在实际使用中发现，地址码更新会导致实名失败，所以提供一种去除地址码的固定规则校验，不随政策随时变化，更适合企业生产环境使用。


___

## **Type**
Enhancement, Tests


___

## **Description**
- Added a new Go package `idvalidator` with functions to validate and extract basic ID card information excluding address code.
- Implemented `IsValidBasic` to validate ID cards based on order code, birthday code, and check bit, excluding address code.
- Implemented `GetBasicInfo` to extract information such as birthday, sex, and zodiac signs from ID cards.
- Added unit tests to validate the correctness of the ID validation logic and the information extraction functionality.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>id_validator_basic.go</strong><dd><code>Implement Basic ID Validation and Information Extraction</code>&nbsp; </dd></summary>
<hr>
      
id_validator_basic.go

<li>Added a new package <code>idvalidator</code>.<br> <li> Implemented <code>IsValidBasic</code> function to validate ID card numbers <br>excluding address code.<br> <li> Implemented <code>GetBasicInfo</code> function to extract basic ID card information <br>excluding address code.<br> <li> Defined <code>BasicIdInfo</code> struct to hold the extracted ID information.<br>


</details>
    

  </td>
  <td><a href="https://github.com/guanguans/id-validator/pull/47/files#diff-7a68ae02dd50501a6cc9e56657c5da0036ef72f431148eb1cecc3cef7c192caa">+73/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>id_validator_basic_test.go</strong><dd><code>Add Tests for Basic ID Validation and Information Extraction</code></dd></summary>
<hr>
      
id_validator_basic_test.go

<li>Added tests for <code>IsValidBasic</code> to ensure it correctly identifies invalid <br>IDs.<br> <li> Added tests for <code>GetBasicInfo</code> to ensure it returns correct results and <br>errors appropriately.<br>


</details>
    

  </td>
  <td><a href="https://github.com/guanguans/id-validator/pull/47/files#diff-856666ca04f26a32d1c4dd50e54969fb208a81f942401d4e04cdfe9d5ddea721">+36/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

