### PR TITLE
fix:time.Date() will panic when loc is nil

### DIFF
--- a/id_validator.go
+++ b/id_validator.go
@@ -79,7 +79,10 @@ func GetInfo(id string, strict bool) (IdInfo, error) {
 	}
 
 	// 生日
-	cst, _ := time.LoadLocation("Asia/Shanghai")
+	cst, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		cst = time.FixedZone("CST", 8*3600)
+	}
 	birthday, _ := time.ParseInLocation("20060102", code["birthdayCode"], cst)
 
 	// 性别


### PR DESCRIPTION
### **User description**
如果系统中缺少时区数据库或者Go进程没有权限读取系统时区文件，以下操作会 panic。
```go
cst, _:= time.LoadLocation("Asia/Shanghai")
// cst 会是nil，接着后续的 time.Date() 会panic
```
对于非开发者的机器，这种情况并不少见。

另一种方法是内置 zoneinfo 数据，但最好还是不要忽略该异常，因为我们不能保证一定能加载到想要的时区。


___

### **PR Type**
Bug fix


___

### **Description**
- Fix panic when timezone data unavailable

- Add fallback to fixed CST timezone

- Handle `time.LoadLocation` error gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["time.LoadLocation"] --> B{"Error?"}
  B -->|Yes| C["Use FixedZone CST"]
  B -->|No| D["Use loaded timezone"]
  C --> E["time.ParseInLocation"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>id_validator.go</strong><dd><code>Add timezone loading error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

id_validator.go

<ul><li>Add error handling for <code>time.LoadLocation("Asia/Shanghai")</code><br> <li> Implement fallback using <code>time.FixedZone("CST", 8*3600)</code><br> <li> Prevent panic when timezone database unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/guanguans/id-validator/pull/58/files#diff-9b63bd0ea222a1a35479bef56017770282df39ab0e68650c08609f642795d68d">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

